### PR TITLE
Improve training config

### DIFF
--- a/annotated_mpnet/data/mpnet_data.py
+++ b/annotated_mpnet/data/mpnet_data.py
@@ -3,8 +3,9 @@ Module containing the logic for handling the dataset for MPNet including the Dat
 as the data collator
 """
 
-import os
 import logging
+import os
+import random
 from typing import Dict, Iterator, Sized
 
 from rich.logging import RichHandler
@@ -15,12 +16,12 @@ logging.basicConfig(
 )
 LOGGER = logging.getLogger(__name__)
 
+
 import numpy as np
 import torch
+from datasets import load_dataset
 from torch.utils.data import Sampler
 from transformers import PreTrainedTokenizer
-from datasets import load_dataset
-import random
 
 from annotated_mpnet.utils import utils
 from annotated_mpnet.utils.perm_utils_fast import make_span_perm

--- a/annotated_mpnet/modeling/mpnet_for_pretraining.py
+++ b/annotated_mpnet/modeling/mpnet_for_pretraining.py
@@ -534,6 +534,10 @@ def make_query_and_content_mask(
                              [ 0 0 0 0 1 1 1 0 0 0 ]
                              [ 0 0 0 0 1 1 1 0 0 0 ]
                              [ 0 0 0 0 1 1 1 0 0 0 ]
+
+    Note: This function is designed to scale automatically with sequence length as it's
+    matrix-based and constructs masks based on the provided seq_len and pred_size.
+    There's no need to modify this function when changing context length.
     """
 
     # Define helper function to keep things organized

--- a/annotated_mpnet/modeling/mpnet_for_pretraining.py
+++ b/annotated_mpnet/modeling/mpnet_for_pretraining.py
@@ -72,6 +72,8 @@ class MPNetForPretraining(nn.Module):
             encoder_normalize_before=True,
             activation_fn=args.activation_fn,
             normalize_before=args.normalize_before,
+            relative_attention_num_buckets=args.relative_attention_num_buckets,
+            relative_attention_max_distance=args.relative_attention_max_distance,
         )
 
         # Add the language modeling head

--- a/annotated_mpnet/transformer_modules/sentence_encoder.py
+++ b/annotated_mpnet/transformer_modules/sentence_encoder.py
@@ -177,7 +177,9 @@ class SentenceEncoder(nn.Module):
 
         if relative_attention_max_distance is None:
             # linear scaling of max distance based on seq len (round up to nearest 8)
-            scaled_max_distance = int(base_max_distance * max_seq_len / base_context)
+            scaled_max_distance = max(
+                128, int(base_max_distance * max_seq_len / base_context)
+            )
             self.relative_attention_max_distance = (scaled_max_distance + 7) // 8 * 8
         else:
             self.relative_attention_max_distance = relative_attention_max_distance

--- a/annotated_mpnet/transformer_modules/sentence_encoder.py
+++ b/annotated_mpnet/transformer_modules/sentence_encoder.py
@@ -71,7 +71,8 @@ class SentenceEncoder(nn.Module):
         embed_scale: float = None,
         freeze_embeddings: bool = False,
         n_trans_layers_to_freeze: int = 0,
-        relative_attention_num_buckets: int = 32,
+        relative_attention_num_buckets: int = None,
+        relative_attention_max_distance: int = None,
         normalize_before: bool = False,
         export: bool = False,
     ) -> None:
@@ -115,6 +116,8 @@ class SentenceEncoder(nn.Module):
                 This is probably only useful for finetuning
             relative_attention_num_buckets: the number of buckets to add to the relative atttention
                 portion of the attention mechanism
+            relative_attention_max_distance: the maximum distance (in tokens) to consider in the relative
+                attention mechanism
             normalize_before: boolean dictating if a layer norm should be applied before the encoder
                 layers
             export: boolean dictating ONNX exporting, which I think we won't be using
@@ -160,7 +163,25 @@ class SentenceEncoder(nn.Module):
         )
 
         # Set up relative attention bias for the attention mechanism
-        self.relative_attention_num_buckets = relative_attention_num_buckets
+        # and compute params for relative attention if they are not specified
+        base_context = 512
+        base_buckets = 32  # Default buckets for 512 context length is 32
+        base_max_distance = 128  # Default max distance for 512 context length is 128
+
+        if relative_attention_num_buckets is None:
+            # linear scaling of num buckets based on seq len (round up to nearest 8)
+            scaled_buckets = max(32, int(base_buckets * max_seq_len / base_context))
+            self.relative_attention_num_buckets = (scaled_buckets + 7) // 8 * 8
+        else:
+            self.relative_attention_num_buckets = relative_attention_num_buckets
+
+        if relative_attention_max_distance is None:
+            # linear scaling of max distance based on seq len (round up to nearest 8)
+            scaled_max_distance = int(base_max_distance * max_seq_len / base_context)
+            self.relative_attention_max_distance = (scaled_max_distance + 7) // 8 * 8
+        else:
+            self.relative_attention_max_distance = relative_attention_max_distance
+
         self.relative_attention_bias = nn.Embedding(
             self.relative_attention_num_buckets, num_attention_heads, padding_idx=None
         )
@@ -259,7 +280,7 @@ class SentenceEncoder(nn.Module):
 
         # Compute the relative attention bias
         positions_bias = self.compute_position_bias(
-            x, self.relative_attention_num_buckets
+            x, self.relative_attention_num_buckets, self.relative_attention_max_distance
         )
 
         # If the user wants ALL hidden states, we keep track of it here

--- a/annotated_mpnet/transformer_modules/sentence_encoder.py
+++ b/annotated_mpnet/transformer_modules/sentence_encoder.py
@@ -317,7 +317,23 @@ class SentenceEncoder(nn.Module):
         return values
 
     @staticmethod
-    def relative_position_bucket(relative_position, num_buckets=32, max_distance=128):
+    def relative_position_bucket(
+        relative_position, num_buckets: int = 32, max_distance: int = 128
+    ):
+        """
+        Computes the relative position bias for a given tensor of relative positions.
+
+        Args:
+            relative_position: Tensor of shape (bsz, qlen, klen) containing the relative
+                positions between the queries and keys.
+            num_buckets: The number of buckets to use for the relative position bias.
+                Defaults to 32.
+            max_distance: The maximum distance to consider when computing the relative
+                position bias. Defaults to 128.
+
+        Returns:
+            A tensor of shape (bsz, qlen, klen) containing the relative position biases.
+        """
         ret = 0
         n = -relative_position
 

--- a/annotated_mpnet/transformer_modules/sentence_encoder_layer.py
+++ b/annotated_mpnet/transformer_modules/sentence_encoder_layer.py
@@ -56,9 +56,7 @@ class SentenceEncoderLayer(nn.Module):
                 forward pass
             attention_dropout: similar to above, but is the dropout prob within the self-attention
                 mechanism
-            activation_fn: the activation function you will be using in this network. Although ReLU
-                is the default, more and more evidence points towards GELU being better for large
-                NLP-based transformers
+            activation_fn: the activation function you will be using in this network.
             add_bias_kv: boolean that dictates whether or not to add a bias parameter to the K, V
                 matrices in the self-attention mechanism
             add_zero_attn: boolean that dictate whether or not to add zero attention to the

--- a/annotated_mpnet/utils/utils.py
+++ b/annotated_mpnet/utils/utils.py
@@ -13,6 +13,16 @@ import torch.nn.functional as F
 
 INCREMENTAL_STATE_INSTANCE_ID = defaultdict(lambda: 0)
 
+SUPPORTED_ACTIVATIONS = [
+    "relu",
+    "gelu",
+    "gelu_accurate",
+    "silu",
+    "relu2",
+    "tanh",
+    "linear",
+]
+
 
 def _get_full_incremental_state_key(module_instance, key):
     module_name = module_instance.__class__.__name__
@@ -72,7 +82,9 @@ def get_activation_fn(activation: str) -> Callable:
     elif activation == "linear":
         return lambda x: x
     else:
-        raise RuntimeError(f"{activation} is not supported here.")
+        raise ValueError(
+            f"{activation} is not supported. Supported activations:\t{SUPPORTED_ACTIVATIONS}"
+        )
 
 
 def gelu_accurate(x: torch.Tensor) -> torch.Tensor:

--- a/annotated_mpnet/utils/utils.py
+++ b/annotated_mpnet/utils/utils.py
@@ -65,6 +65,8 @@ def get_activation_fn(activation: str) -> Callable:
         return gelu_accurate
     elif activation == "silu":
         return F.silu
+    elif activation == "relu2":
+        return relu_squared
     elif activation == "tanh":
         return torch.tanh
     elif activation == "linear":
@@ -92,6 +94,15 @@ def gelu(x: torch.Tensor) -> torch.Tensor:
         return torch.nn.functional.gelu(x.float()).type_as(x)
     else:
         return x * 0.5 * (1.0 + torch.erf(x / math.sqrt(2.0)))
+
+
+def relu_squared(x: torch.Tensor) -> torch.Tensor:
+    """
+    Applies the relu^2 activation introduced in https://arxiv.org/abs/2109.08668v2
+    """
+    relu_applied = F.relu(x)
+    squared = torch.square(relu_applied)
+    return squared
 
 
 @contextlib.contextmanager

--- a/annotated_mpnet/utils/utils.py
+++ b/annotated_mpnet/utils/utils.py
@@ -63,6 +63,8 @@ def get_activation_fn(activation: str) -> Callable:
         return gelu
     elif activation == "gelu_accurate":
         return gelu_accurate
+    elif activation == "silu":
+        return F.silu
     elif activation == "tanh":
         return torch.tanh
     elif activation == "linear":

--- a/annotated_mpnet/utils/utils.py
+++ b/annotated_mpnet/utils/utils.py
@@ -4,8 +4,9 @@ Utils module exported from fairseq for things we might not need, but it's here a
 
 import contextlib
 import math
+import warnings
 from collections import defaultdict
-from typing import Callable
+from typing import Callable, Dict, Tuple
 
 import numpy as np
 import torch
@@ -130,3 +131,207 @@ def numpy_seed(seed):
         yield
     finally:
         np.random.set_state(state)
+
+
+def validate_tokenizer(tokenizer, verbose=False) -> Tuple[bool, Dict]:
+    """
+    Validates that a tokenizer has all the required attributes and methods
+    needed for MPNet pretraining, compatible with both Fast and non-Fast tokenizers.
+
+    Args:
+        tokenizer: The tokenizer to validate
+        verbose: Whether to print detailed information about validation steps
+
+    Returns:
+        bool: True if the tokenizer is valid for MPNet pretraining
+        dict: Configuration recommendations for using this tokenizer
+    """
+    valid = True
+    issues = []
+    recommendations = {}
+
+    # Check required token attributes
+    if not hasattr(tokenizer, "pad_token") or tokenizer.pad_token is None:
+        valid = False
+        issues.append("Missing pad_token - required in SentenceEncoder initialization")
+
+    if not hasattr(tokenizer, "mask_token") or tokenizer.mask_token is None:
+        valid = False
+        issues.append("Missing mask_token - required for masked language modeling")
+
+    if not hasattr(tokenizer, "mask_token_id") or tokenizer.mask_token_id is None:
+        valid = False
+        issues.append("Missing mask_token_id - required in mask_perm method")
+
+    # Check for pad_token_id (important for functionality)
+    if not hasattr(tokenizer, "pad_token_id") or tokenizer.pad_token_id is None:
+        valid = False
+        issues.append("Missing pad_token_id - required for padding operations")
+
+    # Check vocab (either traditional dict or within the tokenizer's backend)
+    if not hasattr(tokenizer, "vocab_size") or not isinstance(
+        tokenizer.vocab_size, int
+    ):
+        valid = False
+        issues.append("Missing vocab_size - required for model initialization")
+
+    # Check for vocab access (allowing for Fast tokenizer differences)
+    has_vocab_access = False
+    vocab_dict = None
+
+    if hasattr(tokenizer, "vocab") and isinstance(tokenizer.vocab, dict):
+        has_vocab_access = True
+        vocab_dict = tokenizer.vocab
+    elif hasattr(tokenizer, "get_vocab") and callable(tokenizer.get_vocab):
+        try:
+            vocab_dict = tokenizer.get_vocab()
+            if isinstance(vocab_dict, dict):
+                has_vocab_access = True
+        except Exception as e:
+            if verbose:
+                warnings.warn(f"get_vocab() method failed: {e}")
+
+    if not has_vocab_access:
+        valid = False
+        issues.append("Cannot access vocabulary - required for token mapping")
+
+    # Check all_special_ids attribute
+    if not hasattr(tokenizer, "all_special_ids") or not isinstance(
+        tokenizer.all_special_ids, list
+    ):
+        valid = False
+        issues.append(
+            "Missing all_special_ids list - required for token corruption probabilities"
+        )
+
+    # Check required methods
+    if not callable(getattr(tokenizer, "__call__", None)):
+        valid = False
+        issues.append("Missing __call__ method - required for tokenization")
+
+    if not callable(getattr(tokenizer, "pad", None)):
+        valid = False
+        issues.append("Missing pad method - required for batch processing")
+
+    # Test tokenizer functionality
+    try:
+        sample_text = "This is a test sentence."
+        encoding = tokenizer(
+            sample_text, add_special_tokens=True, truncation=True, max_length=10
+        )
+        # More lenient check - just see if we can access input_ids
+        try:
+            input_ids = (
+                encoding["input_ids"]
+                if isinstance(encoding, dict)
+                else encoding.input_ids
+            )
+            if input_ids is None:
+                valid = False
+                issues.append("Tokenizer does not produce input_ids as required")
+        except (KeyError, AttributeError):
+            valid = False
+            issues.append("Cannot access input_ids from tokenizer output")
+    except Exception as e:
+        valid = False
+        issues.append(f"Tokenizer.__call__ test failed: {str(e)}")
+
+    # Test padding functionality
+    try:
+        # Create encodings to pad
+        encodings = [
+            tokenizer("Short text", return_tensors=None),
+            tokenizer("This is a longer text", return_tensors=None),
+        ]
+
+        # Test padding
+        padded = tokenizer.pad(encodings, return_tensors="pt")
+
+        # More lenient check - just see if we can access input_ids
+        try:
+            padded_ids = (
+                padded["input_ids"] if isinstance(padded, dict) else padded.input_ids
+            )
+            if padded_ids is None:
+                valid = False
+                issues.append("Padded output does not contain input_ids")
+        except (KeyError, AttributeError):
+            valid = False
+            issues.append("Cannot access input_ids from padded output")
+    except Exception as e:
+        valid = False
+        issues.append(f"Padding test failed: {str(e)}")
+
+    # Check for wordpiece tokenization (require a substantial number of ## tokens)
+    MIN_WORDPIECE_TOKENS = (
+        100  # Minimum number of ## tokens to consider it a WordPiece tokenizer
+    )
+
+    if vocab_dict:
+        wordpiece_tokens = [
+            t for t in vocab_dict.keys() if isinstance(t, str) and t.startswith("##")
+        ]  # TODO: adjust data collator to support non-wordpiece tokenization
+        wordpiece_count = len(wordpiece_tokens)
+
+        if wordpiece_count >= MIN_WORDPIECE_TOKENS:
+            recommendations["whole_word_mask"] = True
+            if verbose:
+                print(
+                    f"\nDetected WordPiece tokenizer with {wordpiece_count} subword tokens starting with '##'"
+                )
+                print(
+                    "This tokenizer is compatible with MPNet's default whole_word_mask=True setting"
+                )
+        else:
+            recommendations["whole_word_mask"] = False
+            if verbose:
+                print(
+                    f"\nNOTE: tokenizer has only {wordpiece_count} tokens with '##' prefix. "
+                    "This is not a standard WordPiece tokenizer compatible with MPNet's whole word masking. "
+                    "When creating DataCollatorForMaskedPermutedLanguageModeling, set whole_word_mask=False"
+                )
+                print(
+                    "or modify the data collator to support your tokenizer's word boundary convention"
+                )
+
+                # Show a few sample tokens to help identify tokenization scheme
+                if vocab_dict:
+                    sample_tokens = list(vocab_dict.keys())
+                    if len(sample_tokens) > 10:
+                        sample_tokens = sample_tokens[:10]
+                    print(f"\nSample vocabulary tokens: {sample_tokens}")
+
+    # Check for optimal vocab size
+    if hasattr(tokenizer, "vocab_size") and isinstance(tokenizer.vocab_size, int):
+        original_vocab_size = tokenizer.vocab_size
+        target_vocab_size = ((original_vocab_size + 127) // 128) * 128
+
+        if original_vocab_size != target_vocab_size:
+            recommendations["padded_vocab_size"] = target_vocab_size
+            if verbose:
+                print("\nPerformance recommendation:")
+                print(f"  Current vocab_size: {original_vocab_size}")
+                print(
+                    f"  For optimal GPU performance, pad vocabulary to: {target_vocab_size}"
+                )
+
+    # Print validation results
+    if verbose:
+        if valid:
+            print("\nTokenizer validation passed! ✅")
+            if recommendations:
+                print("\nRecommendations:")
+                for k, v in recommendations.items():
+                    print(f"  - {k}: {v}")
+        else:
+            print("\nTokenizer validation failed! ❌")
+            print("\nIssues found:")
+            for i, issue in enumerate(issues):
+                print(f"  {i + 1}. {issue}")
+
+            if recommendations:
+                print("\nRecommendations (if issues are fixed):")
+                for k, v in recommendations.items():
+                    print(f"  - {k}: {v}")
+
+    return valid, recommendations

--- a/cli_tools/convert_pretrained_mpnet_to_hf_model.py
+++ b/cli_tools/convert_pretrained_mpnet_to_hf_model.py
@@ -76,6 +76,7 @@ def convert_mpnet_checkpoint_to_pytorch(
         # same size as max_tokens, since position embeddings start at padding_idx + 1, we need to
         # add 2 to the final count, since the lowest possible position is 2
         max_position_embeddings=mpnet_args.max_positions + 2,
+        relative_attention_num_buckets=mpnet_args.relative_attention_num_buckets,
         hidden_act=mpnet_args.activation_fn,
         layer_norm_eps=1e-5,
     )

--- a/cli_tools/pretrain_mpnet.py
+++ b/cli_tools/pretrain_mpnet.py
@@ -145,9 +145,9 @@ def main(args) -> None:
         args.tokenizer_name, model_max_length=args.max_tokens
     )
     is_valid, details = validate_tokenizer(tokenizer)
-    assert is_valid and details["whole_word_mask"], (
-        f"Invalid tokenizer: {args.tokenizer_name}. Debug w/ verbose output from validate_tokenizer()"
-    )
+    assert (
+        is_valid and details["whole_word_mask"]
+    ), f"Invalid tokenizer: {args.tokenizer_name}. Debug w/ verbose output from validate_tokenizer()"
 
     # Check and adjust model vocab_size for better GPU performance
     original_vocab_size = tokenizer.vocab_size
@@ -1040,7 +1040,7 @@ def cli_main():
     parser.add_argument(
         "--num-workers",
         help="Number of worker processes for data loading.",
-        default=int(os.cpu_count() // 2),
+        default=min(4, os.cpu_count()),
         type=int,
     )
     parser.add_argument(

--- a/cli_tools/pretrain_mpnet.py
+++ b/cli_tools/pretrain_mpnet.py
@@ -818,9 +818,9 @@ def cli_main():
         type=str,
     )
     parser.add_argument(
+        "-prenorm",
         "--normalize-before",
-        help="This boolean determines when layer norm should be applied within each encoder layer. "
-        "Generally, we normalize after, but you can specify normalizing before here",
+        help="Determines when layer norm should be applied within each encoder layer.",
         action="store_true",
         default=False,
     )
@@ -884,6 +884,7 @@ def cli_main():
         type=int,
     )
     parser.add_argument(
+        "-warmup_steps",
         "--warmup-updates",
         help="The number of warmup updates to increase the learning rate to --peak-lr before "
         "decreasing it again. Will default to 0.1 of --total-updates if left unset",
@@ -899,8 +900,9 @@ def cli_main():
     parser.add_argument(
         "-gc_steps",
         "--update-freq",
-        help="The amount of batches to process before updating the weights in the model. This is "
-        "what gradient accumulation is",
+        help="Amount of batches to process before updating the weights in the model, "
+        "also known as gradient accumulation. Used to increase effective batch size without "
+        "having to fit it all into memory.",
         default=8,
         type=int,
     )
@@ -917,8 +919,9 @@ def cli_main():
         type=float,
     )
     parser.add_argument(
+        "-wd",
         "--weight-decay",
-        help="The weight decay fed into the Adam optimizer. Usually always set to 0.01",
+        help="The weight decay for the AdamW optimizer.",
         default=0.01,
         type=float,
     )
@@ -931,15 +934,14 @@ def cli_main():
     )
     parser.add_argument(
         "--lr",
-        help="The learning rate that will be hit when the warmup updates have finished",
+        help="Peak learning rate that will be hit when the warmup updates have finished",
         default=6e-4,
         type=float,
     )
     parser.add_argument(
         "-end_lr",
         "--end-learning-rate",
-        help="The learning rate that the polynomial scheduler will approach when decreasing after "
-        "the warmup updates have wrapped up",
+        help="Target learning rate that the polynomial scheduler will slowly decrease to after warm-up.",
         default=0.0,
         type=float,
     )
@@ -977,7 +979,7 @@ def cli_main():
     )
     parser.add_argument(
         "--debug",
-        help="Boolean that dictates whether or not to output debug logs",
+        help="Whether or not to output debug logs",
         action="store_true",
         default=False,
     )
@@ -995,7 +997,7 @@ def cli_main():
     )
     parser.add_argument(
         "--compile",
-        help="Boolean that dictates whether or not to compile the model",
+        help="Whether or not to compile the model",
         action="store_true",
         default=False,
     )

--- a/cli_tools/pretrain_mpnet.py
+++ b/cli_tools/pretrain_mpnet.py
@@ -172,8 +172,12 @@ def main(args) -> None:
     mplm = DataCollatorForMaskedPermutedLanguageModeling(tokenizer=tokenizer)
 
     # sync args for relative attention with model
-    args.relative_attention_num_buckets = model.relative_attention_num_buckets
-    args.relative_attention_max_distance = model.relative_attention_max_distance
+    args.relative_attention_num_buckets = (
+        model.sentence_encoder.relative_attention_num_buckets
+    )
+    args.relative_attention_max_distance = (
+        model.sentence_encoder.relative_attention_max_distance
+    )
 
     # Load the model up to the device
     model.to(device)

--- a/cli_tools/pretrain_mpnet.py
+++ b/cli_tools/pretrain_mpnet.py
@@ -474,9 +474,9 @@ def main(args) -> None:
             accumulation_acc += acc
             accumulation_loss += loss.item()  # Save the original loss value for metrics
 
-            # Scale the loss by update_freq before backward
-            # This ensures gradients are properly scaled from the start
-            scaled_loss = loss / args.update_freq
+            # Divide by batch_size to normalize per-token
+            # Divide by update_freq to account for gradient accumulation
+            scaled_loss = loss / batch_size / args.update_freq
             scaled_loss.backward()
 
             # Check if we've reached a gradient accumulation step

--- a/cli_tools/pretrain_mpnet.py
+++ b/cli_tools/pretrain_mpnet.py
@@ -145,9 +145,9 @@ def main(args) -> None:
         args.tokenizer_name, model_max_length=args.max_tokens
     )
     is_valid, details = validate_tokenizer(tokenizer)
-    assert (
-        is_valid and details["whole_word_mask"]
-    ), f"Invalid tokenizer: {args.tokenizer_name}. Debug w/ verbose output from validate_tokenizer()"
+    assert is_valid and details["whole_word_mask"], (
+        f"Invalid tokenizer: {args.tokenizer_name}. Debug w/ verbose output from validate_tokenizer()"
+    )
 
     # Check and adjust model vocab_size for better GPU performance
     original_vocab_size = tokenizer.vocab_size
@@ -443,13 +443,16 @@ def main(args) -> None:
                     os.path.join(args.checkpoint_dir, f"checkpoint{steps + 1}.pt"),
                 )
 
-                # Save the args if this is the first checkpoint
+                # Save the args & tokenizer if this is the first checkpoint
                 if not initial_outputs_saved:
                     args_dict = vars(args) if not isinstance(args, dict) else args
                     with open(
                         os.path.join(args.checkpoint_dir, "training_args.json"), "w"
                     ) as f:
                         json.dump(args_dict, f, indent=4)
+                    tokenizer.save_pretrained(
+                        os.path.join(args.checkpoint_dir, "tokenizer")
+                    )
                     initial_outputs_saved = True
 
             # Load the tensors onto the appropriate device
@@ -559,6 +562,7 @@ def main(args) -> None:
                 #   tokens the model has seen
                 # tpb:
                 #   tokens per batch, averaging out the tokens processed per batch
+
                 logging_dict = {
                     "acc": meters["train_acc"].avg,
                     "loss": normal_loss,

--- a/cli_tools/pretrain_mpnet.py
+++ b/cli_tools/pretrain_mpnet.py
@@ -925,9 +925,8 @@ def cli_main():
     parser.add_argument(
         "-grad_clip",
         "--clip-grad-norm",
-        help="The value above which to clip gradients down to. Usually should be 0 for pretraining "
-        "and will be set that way by default",
-        default=0.0,
+        help="The value above which to clip gradients down to.",
+        default=1.0,
         type=float,
     )
     parser.add_argument(

--- a/cli_tools/pretrain_mpnet.py
+++ b/cli_tools/pretrain_mpnet.py
@@ -822,7 +822,7 @@ def cli_main():
         type=int,
     )
     parser.add_argument(
-        "-num-buckets",
+        "-num_buckets",
         "--relative-attention-num-buckets",
         help="Number of buckets for relative position. If not set, will automatically compute "
         "the number of buckets based on the max sequence length.",

--- a/cli_tools/pretrain_mpnet.py
+++ b/cli_tools/pretrain_mpnet.py
@@ -932,7 +932,7 @@ def cli_main():
     parser.add_argument(
         "--lr",
         help="The learning rate that will be hit when the warmup updates have finished",
-        default=0.0002,
+        default=6e-4,
         type=float,
     )
     parser.add_argument(

--- a/cli_tools/pretrain_mpnet.py
+++ b/cli_tools/pretrain_mpnet.py
@@ -171,6 +171,10 @@ def main(args) -> None:
     model = MPNetForPretraining(args, tokenizer)
     mplm = DataCollatorForMaskedPermutedLanguageModeling(tokenizer=tokenizer)
 
+    # sync args for relative attention with model
+    args.relative_attention_num_buckets = model.relative_attention_num_buckets
+    args.relative_attention_max_distance = model.relative_attention_max_distance
+
     # Load the model up to the device
     model.to(device)
 
@@ -811,6 +815,21 @@ def cli_main():
         "different. However, this is not advised, so you should only set one of these. Max tokens "
         "will default to 512",
         default=512,
+        type=int,
+    )
+    parser.add_argument(
+        "-num-buckets",
+        "--relative-attention-num-buckets",
+        help="Number of buckets for relative position. If not set, will automatically compute "
+        "the number of buckets based on the max sequence length.",
+        default=None,
+        type=int,
+    )
+    parser.add_argument(
+        "--relative-attention-max-distance",
+        help="Maximum distance for relative position. If not set, will automatically compute "
+        "the maximum distance based on the max sequence length.",
+        default=None,
         type=int,
     )
     parser.add_argument(

--- a/cli_tools/pretrain_mpnet.py
+++ b/cli_tools/pretrain_mpnet.py
@@ -744,32 +744,32 @@ def cli_main():
         description="Pretrain an MPNet model with a huggingface dataset "
         "or path(s) to local training/eval data",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        epilog="Default args follow the MPNet-base params described in the paper: "
+        "https://arxiv.org/abs/2004.09297",
     )
     parser.add_argument(
         "--encoder-layers",
-        help="The number of encoder layers within the encoder block of MPNet. Defaults to 12, but "
-        "can be increased for larger input sequences",
+        help="The number of encoder layers within the encoder block of MPNet. Subsequent "
+        "papers typically use 12-24 encoder layers.",
         default=12,
         type=int,
     )
     parser.add_argument(
         "--encoder-embed-dim",
-        help="The dimension of the embedding layer inside each encoder block. Should generally "
-        "always be 768, but some folks like OpenAI have seen good performance with large embeds",
+        help="The dimension of the embedding layer inside each encoder block. Generally 768-1024.",
         default=768,
         type=int,
     )
     parser.add_argument(
         "--encoder-ffn-dim",
         help="The dimension of the feed-forward hidden layer after each self-attention "
-        "calculation. Defaults to 3072, but this can be any large number",
+        "calculation. Typically 3-4x the embedding dimension",
         default=3072,
         type=int,
     )
     parser.add_argument(
         "--encoder-attention-heads",
-        help="The number of attention heads in each layer. Defaults to 12 which is what's used in"
-        "bert-base and mpnet-base, but this can lend itself to some experimentation",
+        help="The number of attention heads in each layer. Typically 8-16",
         default=12,
         type=int,
     )

--- a/cli_tools/pretrain_mpnet.py
+++ b/cli_tools/pretrain_mpnet.py
@@ -485,7 +485,7 @@ def main(args) -> None:
                 if args.clip_grad_norm > 0.0:
                     gnorm = torch.nn.utils.clip_grad_norm_(
                         model.parameters(), args.clip_grad_norm
-                    )
+                    ).item()
                 else:
                     gnorm = math.sqrt(
                         sum(
@@ -493,7 +493,7 @@ def main(args) -> None:
                             for p in model.parameters()
                             if p.grad is not None
                         )
-                    )
+                    ) # record gradient norm for logging
 
                 # Now we step the scheduler (and return the LR so that we can store it)
                 lr = scheduler.step(steps)

--- a/cli_tools/pretrain_mpnet.py
+++ b/cli_tools/pretrain_mpnet.py
@@ -36,6 +36,7 @@ from annotated_mpnet.data import (
 from annotated_mpnet.modeling import MPNetForPretraining
 from annotated_mpnet.scheduler import PolynomialDecayLRScheduler
 from annotated_mpnet.tracking import AverageMeter
+from annotated_mpnet.utils.utils import SUPPORTED_ACTIVATIONS
 
 
 def accuracy(output: torch.Tensor, target: torch.Tensor) -> int:
@@ -305,7 +306,7 @@ def main(args) -> None:
     optimizer = torch.optim.AdamW(
         filter(lambda p: p.requires_grad, model.parameters()),
         betas=(args.beta1, args.beta2),
-        lr=6e-9,
+        lr=6e-9,  # starting learning rate during warmup
         eps=args.adam_eps,
         weight_decay=args.weight_decay,
         fused=True,
@@ -740,7 +741,8 @@ def cli_main():
     Wrapper function so we can create a CLI entrypoint for this script
     """
     parser = argparse.ArgumentParser(
-        description="Pretrain MPNet by specifying encoder args and training filepath",
+        description="Pretrain an MPNet model with a huggingface dataset "
+        "or path(s) to local training/eval data",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
@@ -808,9 +810,10 @@ def cli_main():
         type=int,
     )
     parser.add_argument(
+        "-activation",
         "--activation-fn",
-        help="The activation function used throughout the model. This will default to GELU, since "
-        "most research on language models has shown optimal performance with GELU",
+        help="The activation function used throughout the model. Supported activations:\t"
+        f"{', '.join(SUPPORTED_ACTIVATIONS)}",
         default="gelu",
         type=str,
     )

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ extensions = [
 
 setup(
     name="annotated_mpnet",
-    version="0.1.2",
+    version="0.1.3",
     description="Raw Torch, heavily annotated, pretrainable MPNet",
     url="https://github.com/pszemraj/annotated-mpnet",
     long_description=readme,
@@ -73,7 +73,7 @@ setup(
         "numpy",
         "rich",
         "tensorboard",
-        "torch",
+        "torch>=2.6.0",
         "transformers",
     ],
     packages=find_packages(exclude=["cli_tools", "tests"]),


### PR DESCRIPTION
This PR aims to bring improvements to the training args used for pretraining MPNet from several angles:

1. improved default values for the training args[^1] and updates to some to more closely follow hyperparams in MPNet paper
2. clearer, more succinct descriptions of what the core args are/do and how to use them
3. addition of new A) options for some existing training args[^2] and B) exposing/integrating some hardcoded parameters[^3] to new CLI args to be adjustable by the user 

[^1]: i.e. like grad clip which has become standard during pretrain since the original repo came out
[^2]: added support for new activation fns "silu" and "relu2"
[^3]: the relaative attention hyperparams `relative_attention_num_buckets` and `max_distance` are hardcoded to values for 512 ctx, dhould be set-able by user w/ reasonable defaults