### PR TITLE
streamline tensor ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ pip install -e .
 
 - Python 3.x
 - PyTorch (version >= 2.6.0, CUDA is required for training)
+- `einops` (version >= 0.7.0) for explicit tensor shape transforms
 - CUDA GPU with BF16 support (Ampere+). As of 2026, legacy GPUs without BF16 are not supported.
 - HuggingFace `transformers`, `datasets`
 - `wandb` (for Weights & Biases logging, optional)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Annotated MPNet
 
-`annotated-mpnet` provides a lightweight, heavily annotated, and standalone PyTorch implementation for pretraining MPNet models. This project aims to demystify the MPNet pretraining process, which was originally part of the larger `fairseq` codebase, making it more accessible for research and custom pretraining.
+`annotated-mpnet` provides a lightweight, heavily annotated, and PyTorch/einops implementation for pretraining MPNet models. This project aims to demystify the MPNet pretraining process, originally part of the larger `fairseq` codebase, making it more accessible for research and custom pretraining.
 
 ---
 
 - [About the Project](#about-the-project)
 - [Key Features](#key-features)
 - [Installation](#installation)
+  - [Requirements](#requirements)
 - [Quick Start](#quick-start)
 - [Documentation](#documentation)
 - [Project Structure](#project-structure)
@@ -22,7 +23,7 @@
 > [!NOTE]
 > **This repo** is a fork/update of the [original by yext](https://github.com/yext/annotated-mpnet).
 
-MPNet (Masked and Permuted Pre-training for Language Understanding) is a powerful pretraining method. However, its original pretraining code is embedded within the `fairseq` library, which can be complex to navigate and adapt. `annotated-mpnet` addresses this by:
+MPNet ([Masked and Permuted Pre-training for Language Understanding](https://arxiv.org/abs/2004.09297)) is a powerful pretraining method. However, its [original pretraining code](https://github.com/microsoft/MPNet) is embedded within the `fairseq` library, which can be complex to navigate and adapt. `annotated-mpnet` addresses this by:
 
 - Providing a clean, raw PyTorch implementation of MPNet pretraining.
 - Offering extensive annotations and comments throughout the codebase to improve understanding.

--- a/annotated_mpnet/modeling/mpnet_for_pretraining.py
+++ b/annotated_mpnet/modeling/mpnet_for_pretraining.py
@@ -648,22 +648,21 @@ def two_stream_self_attention(
 
             # Process bias if applicable
             if bias is not None:
-                if bias.device != attn_weights.device or bias.dtype != attn_weights.dtype:
-                    bias = bias.to(device=attn_weights.device, dtype=attn_weights.dtype)
-                if bias.dim() == 3 and bias.size(0) == self.num_heads:
-                    tgt_len = attn_weights.size(1)
-                    src_len = attn_weights.size(2)
-                    attn_weights = attn_weights.view(bsz, self.num_heads, tgt_len, src_len)
-                    attn_weights = attn_weights + bias.unsqueeze(0)
-                    attn_weights = attn_weights.view(bsz * self.num_heads, tgt_len, src_len)
-                elif bias.dim() == 4:
-                    tgt_len = attn_weights.size(1)
-                    src_len = attn_weights.size(2)
-                    attn_weights = attn_weights.view(bsz, self.num_heads, tgt_len, src_len)
-                    attn_weights = attn_weights + bias
-                    attn_weights = attn_weights.view(bsz * self.num_heads, tgt_len, src_len)
-                else:
-                    attn_weights += bias
+                tgt_len = attn_weights.size(1)
+                src_len = attn_weights.size(2)
+                bias = normalize_position_bias(
+                    bias,
+                    bsz,
+                    self.num_heads,
+                    tgt_len,
+                    src_len,
+                    device=attn_weights.device,
+                    dtype=attn_weights.dtype,
+                    expand_batch=False,
+                )
+                attn_weights = attn_weights.view(bsz, self.num_heads, tgt_len, src_len)
+                attn_weights = attn_weights + bias
+                attn_weights = attn_weights.view(bsz * self.num_heads, tgt_len, src_len)
 
             # Process attention masking
             if mask is not None:

--- a/annotated_mpnet/modeling/mpnet_for_pretraining.py
+++ b/annotated_mpnet/modeling/mpnet_for_pretraining.py
@@ -557,7 +557,11 @@ def two_stream_self_attention(
         attn_bias_from_positions = False
 
         def normalize_attn_mask(mask: torch.Tensor) -> torch.Tensor:
-            """Normalize attention mask to (batch, 1, tgt, src) for SDPA."""
+            """Normalize attention mask to (batch, 1, tgt, src) for SDPA.
+
+            :param torch.Tensor mask: Attention mask tensor to normalize.
+            :return torch.Tensor: Normalized attention mask.
+            """
             if mask.dtype == torch.bool:
                 mask = mask.to(device=device)
             else:
@@ -735,7 +739,10 @@ _TWO_STREAM_MASK_CACHE: "OrderedDict[tuple[int, int, str, int], tuple[torch.Tens
 
 
 def _dynamo_is_compiling() -> bool:
-    """Return True when torch._dynamo is tracing/compiling."""
+    """Return True when torch._dynamo is tracing/compiling.
+
+    :return bool: True if Dynamo is compiling, otherwise False.
+    """
     if hasattr(torch, "_dynamo") and hasattr(torch._dynamo, "is_compiling"):
         return torch._dynamo.is_compiling()
     return False

--- a/annotated_mpnet/transformer_modules/rel_multihead_attention.py
+++ b/annotated_mpnet/transformer_modules/rel_multihead_attention.py
@@ -299,7 +299,15 @@ class RelativeMultiHeadAttention(nn.Module):
             tgt_len: int,
             src_len: int,
         ) -> torch.Tensor:
-            """Add position bias to attention weights with broadcast where possible."""
+            """Add position bias to attention weights with broadcast where possible.
+
+            :param torch.Tensor attn_weights: Attention weights to bias.
+            :param torch.Tensor bias: Position bias tensor.
+            :param int bsz: Batch size.
+            :param int tgt_len: Target sequence length.
+            :param int src_len: Source sequence length.
+            :return torch.Tensor: Biased attention weights.
+            """
             bias = normalize_position_bias(
                 bias,
                 bsz,

--- a/annotated_mpnet/utils/_build_helpers.py
+++ b/annotated_mpnet/utils/_build_helpers.py
@@ -11,6 +11,7 @@ class BuildExt(_build_ext):
     """Custom build_ext to inject NumPy headers and platform flags."""
 
     def finalize_options(self) -> None:
+        """Finalize build options and add NumPy include dirs."""
         super().finalize_options()
         import numpy
 
@@ -19,6 +20,7 @@ class BuildExt(_build_ext):
         self.include_dirs.append(numpy.get_include())
 
     def build_extensions(self) -> None:
+        """Build extensions with platform-specific compile flags."""
         if sys.platform == "darwin":
             extra_compile_args = ["-stdlib=libc++", "-O3"]
         else:

--- a/annotated_mpnet/utils/tensor_ops.py
+++ b/annotated_mpnet/utils/tensor_ops.py
@@ -1,0 +1,83 @@
+"""
+Utility helpers for tensor ops and optional handling.
+"""
+
+from __future__ import annotations
+
+from functools import wraps
+from typing import Any, Callable, Iterable, Optional, TypeVar
+
+import torch
+
+T = TypeVar("T")
+
+
+def exists(value: Any) -> bool:
+    """Return True when a value is not None.
+
+    :param Any value: Value to check.
+    :return bool: True when ``value`` is not None.
+    """
+    return value is not None
+
+
+def maybe(fn: Callable[..., T]) -> Callable[..., Optional[T]]:
+    """Decorate a function to short-circuit when its first argument is None.
+
+    :param Callable fn: Callable to wrap.
+    :return Callable: Wrapped callable returning None when the first arg is None.
+    """
+
+    @wraps(fn)
+    def inner(value: Optional[T], *args: Any, **kwargs: Any) -> Optional[T]:
+        if not exists(value):
+            return None
+        return fn(value, *args, **kwargs)
+
+    return inner
+
+
+def compact(values: Iterable[Optional[T]]) -> list[T]:
+    """Drop None entries from an iterable.
+
+    :param Iterable[Optional[T]] values: Iterable of optional values.
+    :return list[T]: List with None entries removed.
+    """
+    return [value for value in values if value is not None]
+
+
+def reduce_masks(
+    masks: Iterable[Optional[torch.Tensor]],
+    op: Callable[[torch.Tensor, torch.Tensor], torch.Tensor],
+) -> Optional[torch.Tensor]:
+    """Reduce masks with a binary logical op.
+
+    :param Iterable[Optional[torch.Tensor]] masks: Mask tensors to combine.
+    :param Callable op: Binary op to combine masks (e.g., torch.logical_or).
+    :return Optional[torch.Tensor]: Combined mask or None when ``masks`` is empty.
+    """
+    mask_list = compact(masks)
+    if not mask_list:
+        return None
+    mask, *rest = mask_list
+    for other in rest:
+        mask = op(mask, other)
+    return mask
+
+
+def or_masks(masks: Iterable[Optional[torch.Tensor]]) -> Optional[torch.Tensor]:
+    """Combine masks with logical OR.
+
+    :param Iterable[Optional[torch.Tensor]] masks: Mask tensors to combine.
+    :return Optional[torch.Tensor]: Combined mask or None when empty.
+    """
+    return reduce_masks(masks, torch.logical_or)
+
+
+def and_masks(masks: Iterable[Optional[torch.Tensor]]) -> Optional[torch.Tensor]:
+    """Combine masks with logical AND.
+
+    :param Iterable[Optional[torch.Tensor]] masks: Mask tensors to combine.
+    :return Optional[torch.Tensor]: Combined mask or None when empty.
+    """
+    return reduce_masks(masks, torch.logical_and)

--- a/annotated_mpnet/utils/tensor_ops.py
+++ b/annotated_mpnet/utils/tensor_ops.py
@@ -118,6 +118,46 @@ def pad_right_at_dim(
     return torch.cat((tensor, pad_tensor), dim=dim)
 
 
+def slice_at_dim(tensor: torch.Tensor, slc: slice, dim: int = -1) -> torch.Tensor:
+    """Slice a tensor along a specific dimension.
+
+    :param torch.Tensor tensor: Input tensor to slice.
+    :param slice slc: Slice object to apply.
+    :param int dim: Dimension to slice, defaults to -1.
+    :return torch.Tensor: Sliced tensor.
+    """
+    dim = dim if dim >= 0 else tensor.ndim + dim
+    full_slice = [slice(None)] * tensor.ndim
+    full_slice[dim] = slc
+    return tensor[tuple(full_slice)]
+
+
+def slice_left_at_dim(tensor: torch.Tensor, length: int, dim: int = -1) -> torch.Tensor:
+    """Slice the left portion of a tensor along a dimension.
+
+    :param torch.Tensor tensor: Input tensor to slice.
+    :param int length: Length of the left slice.
+    :param int dim: Dimension to slice, defaults to -1.
+    :return torch.Tensor: Left slice of the tensor.
+    """
+    if length == 0:
+        return slice_at_dim(tensor, slice(0, 0), dim=dim)
+    return slice_at_dim(tensor, slice(None, length), dim=dim)
+
+
+def slice_right_at_dim(tensor: torch.Tensor, length: int, dim: int = -1) -> torch.Tensor:
+    """Slice the right portion of a tensor along a dimension.
+
+    :param torch.Tensor tensor: Input tensor to slice.
+    :param int length: Length of the right slice.
+    :param int dim: Dimension to slice, defaults to -1.
+    :return torch.Tensor: Right slice of the tensor.
+    """
+    if length == 0:
+        return slice_at_dim(tensor, slice(0, 0), dim=dim)
+    return slice_at_dim(tensor, slice(-length, None), dim=dim)
+
+
 def compact(values: Iterable[Optional[T]]) -> list[T]:
     """Drop None entries from an iterable.
 

--- a/annotated_mpnet/utils/tensor_ops.py
+++ b/annotated_mpnet/utils/tensor_ops.py
@@ -98,6 +98,26 @@ def normalize_position_bias(
     return bias
 
 
+def pad_right_at_dim(
+    tensor: torch.Tensor, pad: int, dim: int = -1, value: float | int = 0
+) -> torch.Tensor:
+    """Pad a tensor on the right along a specific dimension.
+
+    :param torch.Tensor tensor: Input tensor to pad.
+    :param int pad: Number of values to append.
+    :param int dim: Dimension to pad, defaults to -1.
+    :param float | int value: Pad value, defaults to 0.
+    :return torch.Tensor: Padded tensor.
+    """
+    if pad <= 0:
+        return tensor
+    dim = dim if dim >= 0 else tensor.ndim + dim
+    pad_shape = list(tensor.shape)
+    pad_shape[dim] = pad
+    pad_tensor = tensor.new_full(pad_shape, value)
+    return torch.cat((tensor, pad_tensor), dim=dim)
+
+
 def compact(values: Iterable[Optional[T]]) -> list[T]:
     """Drop None entries from an iterable.
 

--- a/annotated_mpnet/utils/tensor_ops.py
+++ b/annotated_mpnet/utils/tensor_ops.py
@@ -30,6 +30,13 @@ def maybe(fn: Callable[..., T]) -> Callable[..., Optional[T]]:
 
     @wraps(fn)
     def inner(value: Optional[T], *args: Any, **kwargs: Any) -> Optional[T]:
+        """Return None when the first argument is None, otherwise call ``fn``.
+
+        :param Optional[T] value: Primary value to check for None.
+        :param Any args: Positional args forwarded to ``fn``.
+        :param Any kwargs: Keyword args forwarded to ``fn``.
+        :return Optional[T]: ``fn`` result or None.
+        """
         if not exists(value):
             return None
         return fn(value, *args, **kwargs)

--- a/annotated_mpnet/utils/tensor_ops.py
+++ b/annotated_mpnet/utils/tensor_ops.py
@@ -1,5 +1,8 @@
 """
 Utility helpers for tensor ops and optional handling.
+
+largely inspired by/adapted from:
+https://github.com/lucidrains/torch-einops-utils
 """
 
 from __future__ import annotations

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -82,6 +82,7 @@ graph LR
 **Components:**
 
 - **RelativeMultiHeadAttention**: A multi-head self-attention mechanism that incorporates relative positional information, crucial for MPNet. Defined in `annotated_mpnet/transformer_modules/rel_multihead_attention.py`.
+- **Explicit tensor layouts**: Shape transforms in attention and encoder paths use `einops.rearrange` to document and validate expected layouts (e.g., `(t b (h d)) -> (b h) t d`).
 - Position-wise Feed-Forward Networks (FFN).
 - Layer normalization.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,43 +4,67 @@ Complete reference for all `pretrain-mpnet` arguments. Default values follow the
 
 ---
 
+- [Model Architecture](#model-architecture)
+  - [Activation Functions](#activation-functions)
+- [Positional Encoding](#positional-encoding)
+- [Tokenizer](#tokenizer)
+- [Data Source](#data-source)
+  - [HuggingFace Streaming (default)](#huggingface-streaming-default)
+  - [Local Files](#local-files)
+- [Training](#training)
+- [Learning Rate Schedule](#learning-rate-schedule)
+- [Optimizer (AdamW)](#optimizer-adamw)
+- [Checkpoints](#checkpoints)
+- [Resume Training](#resume-training)
+- [Evaluation](#evaluation)
+- [Logging](#logging)
+- [Weights \& Biases](#weights--biases)
+- [Mutual Exclusivity and Constraints](#mutual-exclusivity-and-constraints)
+- [Quick Reference: Common Configurations](#quick-reference-common-configurations)
+  - [MPNet-base (default)](#mpnet-base-default)
+  - [Memory-constrained training](#memory-constrained-training)
+  - [Resumable training](#resumable-training)
+  - [Full logging](#full-logging)
+
+---
+
 ## Model Architecture
 
-| Argument | Type | Default | Description |
-|----------|------|---------|-------------|
-| `--encoder-layers` | `int` | `12` | Number of transformer encoder layers. MPNet-base uses 12; larger models typically use 12--24. |
-| `--encoder-embed-dim` | `int` | `768` | Dimension of token embeddings and hidden states. Must be divisible by `--encoder-attention-heads`. Common values: 768 (base), 1024 (large). |
-| `--encoder-ffn-dim` | `int` | `3072` | Dimension of the feed-forward network hidden layer. Typically 3--4× `--encoder-embed-dim`. |
-| `--encoder-attention-heads` | `int` | `12` | Number of attention heads per layer. `--encoder-embed-dim` must be divisible by this value. |
-| `--dropout` | `float` | `0.1` | Dropout probability applied throughout the encoder (embeddings, attention output, FFN output). |
-| `--attention-dropout` | `float` | `0.1` | Dropout probability applied to attention weights after softmax. |
-| `--activation-dropout` | `float` | `0.1` | Dropout probability applied after the activation function in the FFN hidden layer. |
-| `--normalize-before`, `-prenorm` | `bool` | `False` | Apply layer normalization before sublayer operations (Pre-LN) instead of after (Post-LN). Pre-LN can improve training stability for deeper models. |
+| Argument                         | Type    | Default | Description                                                                                                                                        |
+| -------------------------------- | ------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--encoder-layers`               | `int`   | `12`    | Number of transformer encoder layers. MPNet-base uses 12; larger models typically use 12--24.                                                      |
+| `--encoder-embed-dim`            | `int`   | `768`   | Dimension of token embeddings and hidden states. Must be divisible by `--encoder-attention-heads`. Common values: 768 (base), 1024 (large).        |
+| `--encoder-ffn-dim`              | `int`   | `3072`  | Dimension of the feed-forward network hidden layer. Typically 3--4× `--encoder-embed-dim`.                                                         |
+| `--encoder-attention-heads`      | `int`   | `12`    | Number of attention heads per layer. `--encoder-embed-dim` must be divisible by this value.                                                        |
+| `--dropout`                      | `float` | `0.1`   | Dropout probability applied throughout the encoder (embeddings, attention output, FFN output).                                                     |
+| `--attention-dropout`            | `float` | `0.1`   | Dropout probability applied to attention weights after softmax.                                                                                    |
+| `--activation-dropout`           | `float` | `0.1`   | Dropout probability applied after the activation function in the FFN hidden layer.                                                                 |
+| `--normalize-before`, `-prenorm` | `bool`  | `False` | Apply layer normalization before sublayer operations (Pre-LN) instead of after (Post-LN). Pre-LN can improve training stability for deeper models. |
 
 ### Activation Functions
 
 The `--activation-fn` (alias `-activation`) argument sets the FFN activation function. Type: `str`, default: `"gelu"`.
 
-| Value | Description |
-|-------|-------------|
-| `gelu` | Gaussian Error Linear Unit (recommended) |
-| `gelu_accurate` | More accurate GELU approximation |
-| `relu` | Rectified Linear Unit |
-| `relu2` | Squared ReLU |
-| `silu` | Sigmoid Linear Unit (SwiGLU) |
-| `tanh` | Hyperbolic tangent |
-| `linear` | No activation (identity) |
+| Value           | Description                              |
+| --------------- | ---------------------------------------- |
+| `gelu`          | Gaussian Error Linear Unit (recommended) |
+| `gelu_accurate` | More accurate GELU approximation         |
+| `relu`          | Rectified Linear Unit                    |
+| `relu2`         | Squared ReLU                             |
+| `silu`          | Sigmoid Linear Unit (SwiGLU)             |
+| `tanh`          | Hyperbolic tangent                       |
+| `linear`        | No activation (identity)                 |
 
 ---
 
 ## Positional Encoding
 
-| Argument | Type | Default | Description |
-|----------|------|---------|-------------|
-| `--max-tokens` | `int` | `512` | Maximum sequence length for input tokens. Sequences longer than this are truncated. Also sets `--max-positions` if unspecified. |
-| `--max-positions` | `int` | `None` | Maximum number of positional embeddings. Defaults to `--max-tokens` if unset. |
-| `--relative-attention-num-buckets`, `-num_buckets` | `int` | `None` | Number of buckets for relative position bias. If unset, automatically computed from sequence length. Typical value: 32. |
-| `--relative-attention-max-distance` | `int` | `None` | Maximum distance for relative position encoding. If unset, automatically computed from sequence length. Typical value: 128. |
+| Argument                                           | Type  | Default | Description                                                                                                                     |
+| -------------------------------------------------- | ----- | ------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `--max-tokens`                                     | `int` | `512`   | Maximum sequence length for input tokens. Sequences longer than this are truncated. Also sets `--max-positions` if unspecified. |
+| `--max-positions`                                  | `int` | `None`  | Maximum number of positional embeddings. Defaults to `--max-tokens` if unset.                                                   |
+| `--relative-attention-num-buckets`, `-num_buckets` | `int` | `None`  | Number of buckets for relative position bias. If unset, automatically computed from sequence length. Typical value: 32.         |
+| `--relative-attention-max-distance`                | `int` | `None`  | Maximum distance for relative position encoding. If unset, automatically computed from sequence length. Typical value: 128.     |
 
 > [!NOTE]
 > `--max-tokens` and `--max-positions` should almost always be the same[^1], so only set one of them.
@@ -54,8 +78,8 @@ The `--activation-fn` (alias `-activation`) argument sets the FFN activation fun
 > [!IMPORTANT]
 > For optimal whole-word masking (`whole_word_mask=True` in the data collator), use a WordPiece-compatible tokenizer.
 
-| Argument | Type | Default | Description |
-|----------|------|---------|-------------|
+| Argument           | Type  | Default                  | Description                                                                                                                              |
+| ------------------ | ----- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | `--tokenizer-name` | `str` | `"microsoft/mpnet-base"` | HuggingFace tokenizer name or path to local tokenizer directory. The tokenizer's vocabulary determines the model's embedding layer size. |
 
 ---
@@ -66,21 +90,21 @@ You must use **either** HuggingFace streaming **or** local files, not both.
 
 ### HuggingFace Streaming (default)
 
-| Argument | Type | Default | Description |
-|----------|------|---------|-------------|
-| `--dataset-name` | `str` | `None` | HuggingFace dataset name (e.g., `"HuggingFaceFW/fineweb-edu"`, `"gair-prox/DCLM-pro"`). When set, overrides file-based paths. Defaults to `"HuggingFaceFW/fineweb-edu"` when no file-based paths are provided. |
-| `--text-field` | `str` | `"text"` | Column name in the dataset containing the text to tokenize. |
-| `--buffer-size` | `int` | `10000` | Size of the shuffle buffer for streaming datasets. Larger buffers give better randomization but use more memory. Recommended: 10000--100000. |
-| `--eval-samples` | `int` | `500` | Number of samples to reserve for validation and test sets when streaming. These are taken from the start of the stream. |
-| `--min-text-length` | `int` | `64` | Minimum character length for text samples. Samples shorter than this are skipped. Set to 0 to disable filtering. |
+| Argument            | Type  | Default  | Description                                                                                                                                                                                                    |
+| ------------------- | ----- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--dataset-name`    | `str` | `None`   | HuggingFace dataset name (e.g., `"HuggingFaceFW/fineweb-edu"`, `"gair-prox/DCLM-pro"`). When set, overrides file-based paths. Defaults to `"HuggingFaceFW/fineweb-edu"` when no file-based paths are provided. |
+| `--text-field`      | `str` | `"text"` | Column name in the dataset containing the text to tokenize.                                                                                                                                                    |
+| `--buffer-size`     | `int` | `10000`  | Size of the shuffle buffer for streaming datasets. Larger buffers give better randomization but use more memory. Recommended: 10000--100000.                                                                   |
+| `--eval-samples`    | `int` | `500`    | Number of samples to reserve for validation and test sets when streaming. These are taken from the start of the stream.                                                                                        |
+| `--min-text-length` | `int` | `64`     | Minimum character length for text samples. Samples shorter than this are skipped. Set to 0 to disable filtering.                                                                                               |
 
 ### Local Files
 
-| Argument | Type | Default | Description |
-|----------|------|---------|-------------|
-| `--train-dir` | `str` | `None` | Directory containing training files. Each file is fully loaded into memory per cycle. |
-| `--valid-file` | `str` | `None` | Path to validation data file. One document/sentence per line. |
-| `--test-file` | `str` | `None` | Path to test data file. One document/sentence per line. |
+| Argument       | Type  | Default | Description                                                                           |
+| -------------- | ----- | ------- | ------------------------------------------------------------------------------------- |
+| `--train-dir`  | `str` | `None`  | Directory containing training files. Each file is fully loaded into memory per cycle. |
+| `--valid-file` | `str` | `None`  | Path to validation data file. One document/sentence per line.                         |
+| `--test-file`  | `str` | `None`  | Path to test data file. One document/sentence per line.                               |
 
 > [!WARNING]
 > For large corpora, prefer `--dataset-name` streaming to avoid running out of CPU RAM.
@@ -89,15 +113,15 @@ You must use **either** HuggingFace streaming **or** local files, not both.
 
 ## Training
 
-| Argument | Type | Default | Description |
-|----------|------|---------|-------------|
-| `--total-updates` | `int` | `10000` | Total number of optimizer update steps. Training is step-based, not epoch-based. The dataset cycles internally as needed. |
-| `--batch-size` | `int` | `16` | Per-GPU batch size (number of sequences per forward pass). |
-| `--update-freq`, `-gc_steps` | `int` | `8` | Gradient accumulation steps. Effective batch size = `batch-size × update-freq × num_gpus`. |
-| `--gradient-checkpointing` | `bool` | `False` | Enable activation checkpointing to reduce memory usage at the cost of ~20% slower training. Recommended for large models or limited VRAM. |
-| `--compile` | `bool` | `False` | Use `torch.compile()` for potential speedup. Experimental; may not work with all configurations. |
-| `--seed` | `int` | `12345` | Random seed for reproducibility. Affects model initialization, data shuffling, and masking. |
-| `--num-workers` | `int` | `0` | Number of DataLoader worker processes. |
+| Argument                     | Type   | Default | Description                                                                                                                               |
+| ---------------------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `--total-updates`            | `int`  | `10000` | Total number of optimizer update steps. Training is step-based, not epoch-based. The dataset cycles internally as needed.                 |
+| `--batch-size`               | `int`  | `16`    | Per-GPU batch size (number of sequences per forward pass).                                                                                |
+| `--update-freq`, `-gc_steps` | `int`  | `8`     | Gradient accumulation steps. Effective batch size = `batch-size × update-freq × num_gpus`.                                                |
+| `--gradient-checkpointing`   | `bool` | `False` | Enable activation checkpointing to reduce memory usage at the cost of ~20% slower training. Recommended for large models or limited VRAM. |
+| `--compile`                  | `bool` | `False` | Use `torch.compile()` for potential speedup. Experimental; may not work with all configurations.                                          |
+| `--seed`                     | `int`  | `12345` | Random seed for reproducibility. Affects model initialization, data shuffling, and masking.                                               |
+| `--num-workers`              | `int`  | `0`     | Number of DataLoader worker processes.                                                                                                    |
 
 > [!IMPORTANT]
 > Deterministic resume requires `--num-workers 0`. With more workers, data order is best-effort via sample skipping.
@@ -110,46 +134,46 @@ You must use **either** HuggingFace streaming **or** local files, not both.
 
 Uses polynomial decay with linear warmup.
 
-| Argument | Type | Default | Description |
-|----------|------|---------|-------------|
-| `--lr` | `float` | `6e-4` | Peak learning rate reached after warmup completes. |
-| `--warmup-updates`, `-warmup_steps` | `int` | `None` | Number of warmup steps with linearly increasing LR. Defaults to 10% of `--total-updates` if unset. |
-| `--end-learning-rate`, `-end_lr` | `float` | `0.0` | Final learning rate after polynomial decay. Set to 0 for full decay. |
-| `--power` | `float` | `1.0` | Power of the polynomial decay. `1.0` = linear decay; `2.0` = quadratic decay. |
+| Argument                            | Type    | Default | Description                                                                                        |
+| ----------------------------------- | ------- | ------- | -------------------------------------------------------------------------------------------------- |
+| `--lr`                              | `float` | `6e-4`  | Peak learning rate reached after warmup completes.                                                 |
+| `--warmup-updates`, `-warmup_steps` | `int`   | `None`  | Number of warmup steps with linearly increasing LR. Defaults to 10% of `--total-updates` if unset. |
+| `--end-learning-rate`, `-end_lr`    | `float` | `0.0`   | Final learning rate after polynomial decay. Set to 0 for full decay.                               |
+| `--power`                           | `float` | `1.0`   | Power of the polynomial decay. `1.0` = linear decay; `2.0` = quadratic decay.                      |
 
 ---
 
 ## Optimizer (AdamW)
 
-| Argument | Type | Default | Description |
-|----------|------|---------|-------------|
-| `--beta1` | `float` | `0.9` | AdamW first moment coefficient. |
-| `--beta2` | `float` | `0.98` | AdamW second moment coefficient. MPNet uses 0.98 (higher than typical 0.999). |
-| `--weight-decay`, `-wd` | `float` | `0.01` | Weight decay coefficient. Applied to all parameters except biases and layer norm weights. |
-| `--adam-eps` | `float` | `1e-6` | Epsilon for numerical stability in AdamW. |
-| `--clip-grad-norm`, `-grad_clip` | `float` | `1.0` | Maximum gradient norm for gradient clipping. Set to 0 to disable. |
+| Argument                         | Type    | Default | Description                                                                               |
+| -------------------------------- | ------- | ------- | ----------------------------------------------------------------------------------------- |
+| `--beta1`                        | `float` | `0.9`   | AdamW first moment coefficient.                                                           |
+| `--beta2`                        | `float` | `0.98`  | AdamW second moment coefficient. MPNet uses 0.98 (higher than typical 0.999).             |
+| `--weight-decay`, `-wd`          | `float` | `0.01`  | Weight decay coefficient. Applied to all parameters except biases and layer norm weights. |
+| `--adam-eps`                     | `float` | `1e-6`  | Epsilon for numerical stability in AdamW.                                                 |
+| `--clip-grad-norm`, `-grad_clip` | `float` | `1.0`   | Maximum gradient norm for gradient clipping. Set to 0 to disable.                         |
 
 ---
 
 ## Checkpoints
 
-| Argument | Type | Default | Description |
-|----------|------|---------|-------------|
-| `--checkpoint-dir` | `str` | `"./checkpoints"` | Directory for saving checkpoints. Creates `best_checkpoint.pt`, `final_checkpoint.pt`, and interval checkpoints. |
-| `--checkpoint-interval`, `--save-steps` | `int` | `-1` | Save an interval checkpoint every N update steps. `-1` disables interval checkpoints (only best and final are saved). |
-| `--keep-checkpoints` | `int` | `-1` | Number of interval checkpoints to keep. `-1` = keep all, `0` = keep none (only best/final), `N` = keep N most recent. |
-| `--save-optimizer-state` | `bool` | `False` | Save optimizer and scheduler state alongside model weights. **Required for full resume.** |
+| Argument                                | Type   | Default           | Description                                                                                                           |
+| --------------------------------------- | ------ | ----------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `--checkpoint-dir`                      | `str`  | `"./checkpoints"` | Directory for saving checkpoints. Creates `best_checkpoint.pt`, `final_checkpoint.pt`, and interval checkpoints.      |
+| `--checkpoint-interval`, `--save-steps` | `int`  | `-1`              | Save an interval checkpoint every N update steps. `-1` disables interval checkpoints (only best and final are saved). |
+| `--keep-checkpoints`                    | `int`  | `-1`              | Number of interval checkpoints to keep. `-1` = keep all, `0` = keep none (only best/final), `N` = keep N most recent. |
+| `--save-optimizer-state`                | `bool` | `False`           | Save optimizer and scheduler state alongside model weights. **Required for full resume.**                             |
 
 ---
 
 ## Resume Training
 
-| Argument | Type | Default | Description |
-|----------|------|---------|-------------|
-| `--resume` | `bool` | `False` | Enable resume mode. Loads model, optimizer, scheduler, and data state from checkpoint. |
-| `--resume-checkpoint` | `str` | `None` | Explicit path to checkpoint file for resuming. If unset with `--resume`: uses latest interval checkpoint, falls back to `best_checkpoint.pt`. |
-| `--trust-checkpoint` | `bool` | `False` | Allow loading checkpoints without `weights_only=True`. Required for legacy or external `.pt` files. |
-| `--hf-model-path` | `str` | `None` | Path to HuggingFace MPNet model to initialize weights from. Alternative to resuming from repo checkpoints. |
+| Argument              | Type   | Default | Description                                                                                                                                   |
+| --------------------- | ------ | ------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--resume`            | `bool` | `False` | Enable resume mode. Loads model, optimizer, scheduler, and data state from checkpoint.                                                        |
+| `--resume-checkpoint` | `str`  | `None`  | Explicit path to checkpoint file for resuming. If unset with `--resume`: uses latest interval checkpoint, falls back to `best_checkpoint.pt`. |
+| `--trust-checkpoint`  | `bool` | `False` | Allow loading checkpoints without `weights_only=True`. Required for legacy or external `.pt` files.                                           |
+| `--hf-model-path`     | `str`  | `None`  | Path to HuggingFace MPNet model to initialize weights from. Alternative to resuming from repo checkpoints.                                    |
 
 > [!NOTE]
 > Full resume requires checkpoints created by v0.1.5+ (with `data_state`). Legacy checkpoints only initialize weights.
@@ -158,44 +182,44 @@ Uses polynomial decay with linear warmup.
 
 ## Evaluation
 
-| Argument | Type | Default | Description |
-|----------|------|---------|-------------|
-| `--eval-interval-steps` | `int` | `None` | Run validation every N update steps. Defaults to `--checkpoint-interval` if set, otherwise 5000. |
+| Argument                | Type  | Default | Description                                                                                      |
+| ----------------------- | ----- | ------- | ------------------------------------------------------------------------------------------------ |
+| `--eval-interval-steps` | `int` | `None`  | Run validation every N update steps. Defaults to `--checkpoint-interval` if set, otherwise 5000. |
 
 ---
 
 ## Logging
 
-| Argument | Type | Default | Description |
-|----------|------|---------|-------------|
-| `--tensorboard-log-dir`, `-log_dir` | `str` | `None` | Directory for TensorBoard logs. If unset, metrics are logged to console only. |
-| `--logging-steps` | `int` | `25` | Log training metrics every N update steps. |
-| `--debug` | `bool` | `False` | Enable debug logging (verbose output). |
+| Argument                            | Type   | Default | Description                                                                   |
+| ----------------------------------- | ------ | ------- | ----------------------------------------------------------------------------- |
+| `--tensorboard-log-dir`, `-log_dir` | `str`  | `None`  | Directory for TensorBoard logs. If unset, metrics are logged to console only. |
+| `--logging-steps`                   | `int`  | `25`    | Log training metrics every N update steps.                                    |
+| `--debug`                           | `bool` | `False` | Enable debug logging (verbose output).                                        |
 
 ---
 
 ## Weights & Biases
 
-| Argument | Type | Default | Description |
-|----------|------|---------|-------------|
-| `--wandb` | `bool` | `False` | Enable Weights & Biases logging. |
-| `--wandb-project` | `str` | `"annotated-mpnet"` | W&B project name. |
-| `--wandb-name` | `str` | `None` | W&B run name. Auto-generated if unset. |
-| `--wandb-id` | `str` | `None` | W&B run ID for resuming a tracked run. Use with `--resume` to continue logging to the same run. |
-| `--wandb-watch` | `bool` | `False` | Log model gradients to W&B. Increases logging overhead. |
+| Argument          | Type   | Default             | Description                                                                                     |
+| ----------------- | ------ | ------------------- | ----------------------------------------------------------------------------------------------- |
+| `--wandb`         | `bool` | `False`             | Enable Weights & Biases logging.                                                                |
+| `--wandb-project` | `str`  | `"annotated-mpnet"` | W&B project name.                                                                               |
+| `--wandb-name`    | `str`  | `None`              | W&B run name. Auto-generated if unset.                                                          |
+| `--wandb-id`      | `str`  | `None`              | W&B run ID for resuming a tracked run. Use with `--resume` to continue logging to the same run. |
+| `--wandb-watch`   | `bool` | `False`             | Log model gradients to W&B. Increases logging overhead.                                         |
 
 ---
 
 ## Mutual Exclusivity and Constraints
 
-| Constraint | Details |
-|------------|---------|
-| `--dataset-name` vs `--train-dir` | Cannot use both; streaming overrides file-based |
-| `--hf-model-path` vs `--resume` | Cannot combine; use one or the other |
-| `--max-tokens` vs `--max-positions` | Set only one; they must match if both are set |
-| Deterministic resume | Requires `--num-workers 0` for streaming datasets |
-| Full resume | Requires `--save-optimizer-state` during initial training |
-| Full resume | Requires checkpoint from v0.1.5+ (with `data_state`) |
+| Constraint                          | Details                                                   |
+| ----------------------------------- | --------------------------------------------------------- |
+| `--dataset-name` vs `--train-dir`   | Cannot use both; streaming overrides file-based           |
+| `--hf-model-path` vs `--resume`     | Cannot combine; use one or the other                      |
+| `--max-tokens` vs `--max-positions` | Set only one; they must match if both are set             |
+| Deterministic resume                | Requires `--num-workers 0` for streaming datasets         |
+| Full resume                         | Requires `--save-optimizer-state` during initial training |
+| Full resume                         | Requires checkpoint from v0.1.5+ (with `data_state`)      |
 
 ---
 

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -23,67 +23,68 @@ python -m unittest tests.test_pretrain.TestPretrainHelpers.test_weight_decay_gro
 
 Tests for the data collation and streaming functionality. These run on CPU without CUDA.
 
-| Test | What It Verifies |
-|------|------------------|
-| `test_permuted_batch` | Collator produces valid permuted batches with deterministic seeding |
-| `test_collator_skips_special_and_padding_targets` | Targets exclude special tokens (CLS, SEP, PAD, MASK) |
-| `test_collator_has_padding_false_for_equal_lengths` | `has_padding` flag correctly tracks batch padding state |
-| `test_training_seeded_sampling` | `RandomSamplerWithSeed` produces deterministic, epoch-varied orderings |
-| `test_streaming_dataset_skip_and_max` | `HFStreamingDataset` respects `skip_samples` and `max_samples` |
-| `test_streaming_dataset_defers_padding_to_collator` | Streaming dataset does not pre-pad sequences |
-| `test_collator_rng_state_roundtrip` | Collator RNG state save/restore produces identical batches |
-| `test_file_mode_resume_sampler_offset_preserves_collator_rng` | Resume with sampler offset preserves masking determinism |
-| `test_collator_falls_back_without_fast_perm` | Graceful fallback when Cython extension unavailable |
-| `test_streaming_dataset_rng_state_roundtrip` | Streaming dataset RNG state is a no-op (by design) |
+| Test                                                          | What It Verifies                                                       |
+| ------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `test_permuted_batch`                                         | Collator produces valid permuted batches with deterministic seeding    |
+| `test_collator_skips_special_and_padding_targets`             | Targets exclude special tokens (CLS, SEP, PAD, MASK)                   |
+| `test_collator_has_padding_false_for_equal_lengths`           | `has_padding` flag correctly tracks batch padding state                |
+| `test_training_seeded_sampling`                               | `RandomSamplerWithSeed` produces deterministic, epoch-varied orderings |
+| `test_streaming_dataset_skip_and_max`                         | `HFStreamingDataset` respects `skip_samples` and `max_samples`         |
+| `test_streaming_dataset_defers_padding_to_collator`           | Streaming dataset does not pre-pad sequences                           |
+| `test_collator_rng_state_roundtrip`                           | Collator RNG state save/restore produces identical batches             |
+| `test_file_mode_resume_sampler_offset_preserves_collator_rng` | Resume with sampler offset preserves masking determinism               |
+| `test_collator_falls_back_without_fast_perm`                  | Graceful fallback when Cython extension unavailable                    |
+| `test_streaming_dataset_rng_state_roundtrip`                  | Streaming dataset RNG state is a no-op (by design)                     |
 
 ### `tests/test_pretrain.py` - Core Training Logic Tests
 
 Unit tests for pretraining helper functions, model architecture, and training utilities. These run on CPU.
 
-| Test | What It Verifies |
-|------|------------------|
-| `test_get_initial_best_loss` | Best-loss initialization fallback logic |
-| `test_validate_tokenizer_vocab_size_*` | Tokenizer/checkpoint vocab size validation |
-| `test_weight_decay_grouping` | Biases and norm weights excluded from weight decay |
-| `test_polynomial_scheduler_step_indexing` | LR scheduler warmup and decay behavior |
-| `test_init_final_params_zeroes_padding_idx` | Embedding padding_idx=0 zeroed during init |
-| `test_encode_emb_handles_sinusoidal_positions` | Sinusoidal positional embeddings work correctly |
-| `test_hf_max_positions_to_internal` | HF max_positions conversion (subtracts 2 for CLS/SEP) |
-| `test_lm_head_weight_registered_and_tied` | LM head weight tied to embedding weight |
-| `test_sentence_encoder_gradient_checkpointing` | Gradient checkpointing path runs without error |
-| `test_sentence_encoder_inner_states_layout` | Inner states layout consistent across modes |
-| `test_sentence_encoder_positions_*` | Explicit positions follow default semantics |
-| `test_two_stream_attention_padding_mask` | Padding masks stay 2D; SDPA matches non-SDPA |
-| `test_two_stream_mask_layout_matches_reference` | Boolean mask layout matches legacy float construction |
-| `test_resolve_best_loss_*` | Best-loss resolution from various checkpoint sources |
-| `test_get_resume_metadata_*` | Resume metadata extraction for legacy vs. modern checkpoints |
-| `test_select_resume_checkpoint_path_*` | Resume checkpoint selection logic |
-| `test_model_summary_avoids_double_counting` | Parameter counting doesn't double-count nested modules |
-| `test_pretraining_forward_return_mlm` | `return_mlm=True` yields logits with expected shapes |
-| `test_pretraining_gradient_checkpointing_forward` | Pretraining forward runs with gradient checkpointing |
-| `test_prune_checkpoints_keeps_recent` | Checkpoint pruning keeps N most recent |
-| `test_select_architecture_source` | Architecture source selection precedence |
-| `test_select_*_checkpoint_path` | Various checkpoint path selection helpers |
-| `test_should_save_checkpoint` | Checkpoint save decision at exact step boundaries |
-| `test_strip_compile_prefix` | `torch.compile` prefixes removed from state dict |
-| `test_coerce_rng_state` | RNG state coerced to uint8 CPU tensor |
-| `test_apply_checkpoint_architecture_args_*` | Checkpoint args restore model architecture |
-| `test_normalize_training_accuracy` | Training accuracy normalization helper |
-| `test_accuracy_ignores_pad_tokens` | Accuracy calculation ignores padding |
-| `test_count_pred_tokens` | Predicted token counting with padding |
-| `test_autocast_context_cpu_is_noop` | CPU autocast is a no-op |
-| `test_ga_gradients_match_full_batch` | Gradient accumulation matches full-batch gradients |
-| `test_scheduler_state_dict_is_stateless` | Scheduler state_dict is stateless |
+| Test                                              | What It Verifies                                             |
+| ------------------------------------------------- | ------------------------------------------------------------ |
+| `test_get_initial_best_loss`                      | Best-loss initialization fallback logic                      |
+| `test_validate_tokenizer_vocab_size_*`            | Tokenizer/checkpoint vocab size validation                   |
+| `test_weight_decay_grouping`                      | Biases and norm weights excluded from weight decay           |
+| `test_polynomial_scheduler_step_indexing`         | LR scheduler warmup and decay behavior                       |
+| `test_init_final_params_zeroes_padding_idx`       | Embedding padding_idx=0 zeroed during init                   |
+| `test_encode_emb_handles_sinusoidal_positions`    | Sinusoidal positional embeddings work correctly              |
+| `test_hf_max_positions_to_internal`               | HF max_positions conversion (subtracts 2 for CLS/SEP)        |
+| `test_lm_head_weight_registered_and_tied`         | LM head weight tied to embedding weight                      |
+| `test_sentence_encoder_gradient_checkpointing`    | Gradient checkpointing path runs without error               |
+| `test_sentence_encoder_inner_states_layout`       | Inner states layout consistent across modes                  |
+| `test_sentence_encoder_positions_*`               | Explicit positions follow default semantics                  |
+| `test_two_stream_attention_padding_mask`          | Padding masks stay 2D; SDPA matches non-SDPA                 |
+| `test_two_stream_mask_layout_matches_reference`   | Boolean mask layout matches legacy float construction        |
+| `test_resolve_best_loss_*`                        | Best-loss resolution from various checkpoint sources         |
+| `test_get_resume_metadata_*`                      | Resume metadata extraction for legacy vs. modern checkpoints |
+| `test_select_resume_checkpoint_path_*`            | Resume checkpoint selection logic                            |
+| `test_model_summary_avoids_double_counting`       | Parameter counting doesn't double-count nested modules       |
+| `test_pretraining_forward_return_mlm`             | `return_mlm=True` yields logits with expected shapes         |
+| `test_pretraining_gradient_checkpointing_forward` | Pretraining forward runs with gradient checkpointing         |
+| `test_prune_checkpoints_keeps_recent`             | Checkpoint pruning keeps N most recent                       |
+| `test_select_architecture_source`                 | Architecture source selection precedence                     |
+| `test_select_*_checkpoint_path`                   | Various checkpoint path selection helpers                    |
+| `test_should_save_checkpoint`                     | Checkpoint save decision at exact step boundaries            |
+| `test_strip_compile_prefix`                       | `torch.compile` prefixes removed from state dict             |
+| `test_coerce_rng_state`                           | RNG state coerced to uint8 CPU tensor                        |
+| `test_apply_checkpoint_architecture_args_*`       | Checkpoint args restore model architecture                   |
+| `test_normalize_training_accuracy`                | Training accuracy normalization helper                       |
+| `test_accuracy_ignores_pad_tokens`                | Accuracy calculation ignores padding                         |
+| `test_count_pred_tokens`                          | Predicted token counting with padding                        |
+| `test_autocast_context_cpu_is_noop`               | CPU autocast is a no-op                                      |
+| `test_ga_gradients_match_full_batch`              | Gradient accumulation matches full-batch gradients           |
+| `test_scheduler_state_dict_is_stateless`          | Scheduler state_dict is stateless                            |
 
 ### `tests/test_pretrain_smoke.py` - End-to-End Smoke Tests
 
 Integration tests that run actual training. **Requires CUDA.**
 
-| Test | What It Verifies |
-|------|------------------|
+| Test                    | What It Verifies                                 |
+| ----------------------- | ------------------------------------------------ |
 | `test_resume_smoke_run` | Full train + resume cycle on GPU with tiny model |
 
 This test:
+
 1. Creates temporary train/valid/test files
 2. Runs 1 training step with a minimal model
 3. Verifies checkpoints are saved
@@ -93,6 +94,7 @@ This test:
 ### `tests/dummy_tokenizer.py` - Test Fixture
 
 A minimal tokenizer stub for offline unit tests. Implements the subset of the HuggingFace tokenizer API used by the codebase:
+
 - `__call__` for encoding text
 - `pad` for batch padding
 - Special token IDs (PAD, CLS, SEP, MASK, UNK)
@@ -122,6 +124,7 @@ ruff check --fix . && ruff format .
 ## Adding New Tests
 
 Place new tests in the appropriate file based on what they test:
+
 - Data loading/collation: `test_data.py`
 - Model/training logic: `test_pretrain.py`
 - End-to-end training flows: `test_pretrain_smoke.py`

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -113,6 +113,15 @@ Always lint and format before committing:
 ruff check --fix . && ruff format .
 ```
 
+## Docstring Checks
+
+Run the docstring checker against project code (avoid scanning vendored deps):
+
+```bash
+python ~/scripts/py/doc_check.py annotated_mpnet --check-lazy-docstrings
+python ~/scripts/py/doc_check.py cli_tools --check-lazy-docstrings
+```
+
 ## Development Workflow
 
 1. Create a topic branch for your changes

--- a/docs/training.md
+++ b/docs/training.md
@@ -2,6 +2,17 @@
 
 This document covers pretraining MPNet models using `annotated-mpnet`.
 
+---
+
+- [Pretraining MPNet](#pretraining-mpnet)
+  - [Using a HuggingFace Dataset (Streaming)](#using-a-huggingface-dataset-streaming)
+  - [Using Local Text Files](#using-local-text-files)
+- [Key Pretraining Arguments](#key-pretraining-arguments)
+- [Resuming Training](#resuming-training)
+- [Exporting Checkpoint to HuggingFace](#exporting-checkpoint-to-huggingface)
+
+---
+
 ## Pretraining MPNet
 
 The primary script for pretraining is `pretrain-mpnet`. You can see all available arguments by running `pretrain-mpnet -h`.
@@ -9,6 +20,9 @@ The primary script for pretraining is `pretrain-mpnet`. You can see all availabl
 Training is **step-based** (no user-facing epochs). Datasets are cycled and reshuffled internally as needed, and training runs for `--total-updates` steps. Training metrics are logged every 25 update steps by default; adjust with `--logging-steps`.
 
 ### Using a HuggingFace Dataset (Streaming)
+
+> [!NOTE]
+> The default streaming dataset is [fineweb-edu](https://huggingface.co/datasets/HuggingFaceFW/fineweb-edu)
 
 This method streams data directly from the HuggingFace Hub. Validation and test sets are created by taking initial samples from the training stream.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ authors = [{ name = "annotated-mpnet contributors" }]
 dependencies = [
   "cython",
   "datasets",
+  "einops>=0.7.0",
   "numpy",
   "rich",
   "tensorboard",


### PR DESCRIPTION
Refactor tensor ops to einops + normalize attention bias/masks

**Summary**
- Replaced fragile `view/transpose` chains with `einops.rearrange` in attention and encoder paths for explicit tensor layouts.
- Centralized position-bias normalization and mask handling to reduce duplicated shape logic.
- Added small tensor utilities (`pad_right_at_dim`, `slice_*_at_dim`, etc.) and tightened docstrings.
- Updated docs to reflect `einops` requirement and dev docstring checks.

**Key Changes**
- `annotated_mpnet/transformer_modules/rel_multihead_attention.py`
  - `einops` reshapes for Q/K/V and outputs.
  - `pad_right_at_dim` for attention padding.
  - Normalized position-bias handling.
- `annotated_mpnet/modeling/mpnet_for_pretraining.py`
  - `einops` reshapes in two-stream attention.
  - Shared `normalize_position_bias` for bias addition.
  - Normalized attention mask expansion paths.
  - `slice_*_at_dim` for position-bias slicing.
- `annotated_mpnet/utils/tensor_ops.py`
  - Added `pad_right_at_dim`, `slice_*_at_dim`, `normalize_position_bias` helpers.
- Docs
  - Added `einops` to requirements.
  - Noted explicit tensor layouts in architecture docs.
  - Added docstring check commands in dev guide.
